### PR TITLE
Added functionality - directional arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 
 Of course, you can do with much less code than this, but this example should give a good indication on how you can structure your data for a flowchart.
 
-Check out the [demo](https://mariusbrataas.github.io/flowpoints.js/?p=demo) and it's [source code](https://github.com/mariusbrataas/flowpoints/tree/master/demo/src) for more.
+Check out the [demo](https://mariusbrataas.github.io/flowpoints.js/?p=demo) and it's [source code](https://github.com/mariusbrataas/flowpoints.js/tree/master/demo/src) for more.
 
 ## Contributing
 
@@ -304,4 +304,4 @@ flowpoints
 ```
 
 ## License
-[MIT](https://github.com/mariusbrataas/flowpoints/blob/master/LICENSE)
+[MIT](https://github.com/mariusbrataas/flowpoints.js/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Possible locations: top, left, center (default), right, bottom.
   background="white"
   style={{ width:'100vw', height:'100vh' }}
   connectionSize=4
+  arrowStart={false}
+  arrowEnd={true}
   selected="point_a"
   selectedLine={{ a:"point_a", b:"point_b" }}
   onLineClick={(key_a, key_b, e) => {

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Possible locations: top, left, center (default), right, bottom.
       input:"left",
       outputColor:"#0c00ff",
       inputColor:"#ff0022",
+      markerStart: false,
+      markerEnd: true
       onClick: (key_a, key_b, e) => {
         console.log('Click connection ' + key_a + ' -> ' + key_b)
       }
@@ -171,7 +173,7 @@ Possible locations: top, left, center (default), right, bottom.
   > ... </Flowspace>
 ```
 
-Themes, variants and connectionSizes passed to the flowspace will be the default values used when drawing connections. A different value specified by a flowpoint's outputs will replace the default value for that connection only.
+Themes, variants, connectionSizes, arrowStart and arrowEnd settings passed to the flowspace will be the default values used when drawing connections. A different value specified by a flowpoint's outputs will replace the default value for that connection only.
 
 ## Suggested pattern
 

--- a/demo/src/Helpers.js
+++ b/demo/src/Helpers.js
@@ -37,6 +37,13 @@ export const themes = [
   'white'
 ]
 
+export const arrows = [
+  'none',
+  'start',
+  'end',
+  'both'
+]
+
 export const darktheme = createMuiTheme({
   palette: {
     type: 'dark',

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -6,6 +6,7 @@ import { postToDB, getDB } from './DBhandler.js';
 import {
   themes,
   darktheme,
+  arrows,
   parseFromQuery,
   PasswordContainer,
   ReplaceAll,
@@ -65,6 +66,7 @@ class App extends Component {
       theme: 'indigo',
       variant: 'outlined',
       background: 'white',
+      arrow: 'none',
       lastPos: {x:300, y:50},
       snackShow: false,
       snackMsg: '',
@@ -358,6 +360,26 @@ class App extends Component {
                 </FormControl>
               </div>
 
+              <div style={{paddingBottom:10}}>
+                <FormControl style={{width:'100%'}}>
+                  <InputLabel htmlFor='arrowselect'>Arrows</InputLabel>
+                  <Select
+                    value={this.state.arrow}
+                    inputProps={{ name:'arrow select', id:'arrowselect'}}
+                    onChange={(e) => {
+                      this.setState({arrow:e.target.value})
+                    }}>
+                    {
+                      arrows.map(arrowname => {
+                        return (
+                          <MenuItem value={arrowname}>{arrowname}</MenuItem>
+                        )
+                      })
+                    }
+                  </Select>
+                </FormControl>
+              </div>
+
               <div>
                 <FormControl style={{width:'100%'}}>
                   <InputLabel htmlFor='variantselect'>Variant</InputLabel>
@@ -624,6 +646,8 @@ class App extends Component {
             theme={this.state.theme}
             variant={this.state.variant}
             background={this.state.background}
+            arrowStart={this.state.arrow === 'start' || this.state.arrow === 'both'}
+            arrowEnd={this.state.arrow === 'end' || this.state.arrow === 'both'}
             getDiagramRef={ref => {this.diagramRef = ref}}
             avoidCollisions
             style={{height:'100vh', width:'100vw'}}

--- a/src/Flowspace.js
+++ b/src/Flowspace.js
@@ -109,6 +109,8 @@ export default class Flowspace extends Component {
               inputLoc: output.input || 'auto',
               outputColor: output.outputColor || theme_colors.p,
               inputColor: output.inputColor || (this.props.noFade ? theme_colors.p : theme_colors.a),
+              arrowStart: output.arrowStart,
+              arrowEnd: output.arrowStart,
               dash: (output.dash !== undefined ? (output.dash > 0 ? output.dash : undefined) : undefined),
               onClick: output.onClick ? (e) => {output.onClick(child.key, out_key, e)} : this.props.onLineClick ? (e) => {this.props.onLineClick(child.key, out_key, e)} : null
             });
@@ -167,6 +169,12 @@ export default class Flowspace extends Component {
           // Calculate new positions or get old ones
           var positions = AutoGetLoc(pa, pb, connection.outputLoc, connection.inputLoc, connection.a, connection.b, this.state, (this.props.avoidCollisions === false ? false : true));
 
+          // Display arrows - if set then connection-specific overrides flowspace
+          const markerStart = this.props.arrowStart;
+          if (connection.arrowStart !== undefined) markerStart = connection.arrowStart;
+          const markerEnd = this.props.arrowEnd;
+          if (connection.arrowEnd !== undefined) markerEnd = connection.arrowEnd;
+
           // Calculating bezier offsets and adding new path to list
           const d = Math.round(Math.pow(Math.pow(positions.output.x - positions.input.x, 2) + Math.pow(positions.output.y - positions.input.y, 2), 0.5) / 2)
           const pathkey = 'path_' + connection.a + '_' + connection.b
@@ -193,8 +201,9 @@ export default class Flowspace extends Component {
               stroke={'url(#' + grad_name + ')'}
               strokeWidth={parseInt(connection.width) + (isSelectedLine ? 3 : 0)}
               onClick={connection.onClick}
-              marker-start={this.props.arrowStart ? 'url(#arrow)' : null}
-              marker-end={this.props.arrowEnd ? 'url(#arrow)' : null}/>
+              marker-start={markerStart ? 'url(#arrow)' : null}
+              marker-end={markerEnd ? 'url(#arrow)' : null}
+              />
           )
 
           // Calculating how x and y should affect gradient

--- a/src/Flowspace.js
+++ b/src/Flowspace.js
@@ -170,9 +170,9 @@ export default class Flowspace extends Component {
           var positions = AutoGetLoc(pa, pb, connection.outputLoc, connection.inputLoc, connection.a, connection.b, this.state, (this.props.avoidCollisions === false ? false : true));
 
           // Display arrows - if set then connection-specific overrides flowspace
-          const markerStart = this.props.arrowStart;
+          var markerStart = this.props.arrowStart;
           if (connection.arrowStart !== undefined) markerStart = connection.arrowStart;
-          const markerEnd = this.props.arrowEnd;
+          var markerEnd = this.props.arrowEnd;
           if (connection.arrowEnd !== undefined) markerEnd = connection.arrowEnd;
 
           // Calculating bezier offsets and adding new path to list
@@ -201,8 +201,8 @@ export default class Flowspace extends Component {
               stroke={'url(#' + grad_name + ')'}
               strokeWidth={parseInt(connection.width) + (isSelectedLine ? 3 : 0)}
               onClick={connection.onClick}
-              marker-start={markerStart ? 'url(#arrow)' : null}
-              marker-end={markerEnd ? 'url(#arrow)' : null}
+              markerStart={markerStart ? 'url(#arrow)' : null}
+              markerEnd={markerEnd ? 'url(#arrow)' : null}
               />
           )
 
@@ -262,8 +262,8 @@ export default class Flowspace extends Component {
 
             <svg style={{width:'100%', height:'100%', position:'absolute', overflow:'visible'}} className='flowconnections'>
               <def>
-                <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto" >
+                  <path d="M0,0 L0,6 L9,3 z" />
                 </marker>
               </def>
               {

--- a/src/Flowspace.js
+++ b/src/Flowspace.js
@@ -192,7 +192,9 @@ export default class Flowspace extends Component {
               fill="none"
               stroke={'url(#' + grad_name + ')'}
               strokeWidth={parseInt(connection.width) + (isSelectedLine ? 3 : 0)}
-              onClick={connection.onClick}/>
+              onClick={connection.onClick}
+              marker-start={this.props.arrowStart ? 'url(#arrow)' : null}
+              marker-end={this.props.arrowEnd ? 'url(#arrow)' : null}/>
           )
 
           // Calculating how x and y should affect gradient
@@ -250,6 +252,11 @@ export default class Flowspace extends Component {
           <div ref={ref => {if (this.props.getDiagramRef) this.props.getDiagramRef(ref)}} style={{width:'100%', height:'100%', backgroundColor:background_color.p}}>
 
             <svg style={{width:'100%', height:'100%', position:'absolute', overflow:'visible'}} className='flowconnections'>
+              <def>
+                <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+                  <path d="M 0 0 L 10 5 L 0 10 z" />
+                </marker>
+              </def>
               {
                 gradients
               }

--- a/src/Flowspace.js
+++ b/src/Flowspace.js
@@ -69,6 +69,7 @@ export default class Flowspace extends Component {
     var connections = [];
     var paths = [];
     var gradients = [];
+    var defs = {};
     var maxX = 0;
     var maxY = 0;
 
@@ -175,6 +176,16 @@ export default class Flowspace extends Component {
           var markerEnd = this.props.arrowEnd;
           if (connection.arrowEnd !== undefined) markerEnd = connection.arrowEnd;
 
+          // Adding coloured arrow-marker definitions to list (if not already present)
+          if (markerStart && !defs[connection.outputColor]) defs[connection.outputColor] = 
+            <marker id={"arrow" + connection.outputColor} viewBox="0 0 50 50" markerWidth="5" markerHeight="5" refX="45" refY="24" orient="auto-start-reverse" markerUnits="strokeWidth">
+              <path d="M0,0 L50,20 v8 L0,48 L6,24 Z" fill={connection.outputColor} stroke-width='0' opacity='1' />
+            </marker>
+          if (markerEnd && !defs[connection.inputColor]) defs[connection.inputColor] = 
+            <marker id={"arrow" + connection.inputColor} viewBox="0 0 50 50" markerWidth="5" markerHeight="5" refX="45" refY="24" orient="auto-start-reverse" markerUnits="strokeWidth">
+              <path d="M0,0 L50,20 v8 L0,48 L6,24 Z" fill={connection.inputColor} stroke-width='0' opacity='1' />
+            </marker>
+
           // Calculating bezier offsets and adding new path to list
           const d = Math.round(Math.pow(Math.pow(positions.output.x - positions.input.x, 2) + Math.pow(positions.output.y - positions.input.y, 2), 0.5) / 2)
           const pathkey = 'path_' + connection.a + '_' + connection.b
@@ -201,8 +212,8 @@ export default class Flowspace extends Component {
               stroke={'url(#' + grad_name + ')'}
               strokeWidth={parseInt(connection.width) + (isSelectedLine ? 3 : 0)}
               onClick={connection.onClick}
-              markerStart={markerStart ? 'url(#arrow)' : null}
-              markerEnd={markerEnd ? 'url(#arrow)' : null}
+              markerStart={markerStart ? 'url(#arrow' + connection.outputColor + ')' : null}
+              markerEnd={markerEnd ? 'url(#arrow' + connection.inputColor + ')' : null}
               />
           )
 
@@ -261,11 +272,9 @@ export default class Flowspace extends Component {
           <div ref={ref => {if (this.props.getDiagramRef) this.props.getDiagramRef(ref)}} style={{width:'100%', height:'100%', backgroundColor:background_color.p}}>
 
             <svg style={{width:'100%', height:'100%', position:'absolute', overflow:'visible'}} className='flowconnections'>
-              <def>
-                <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto" >
-                  <path d="M0,0 L0,6 L9,3 z" />
-                </marker>
-              </def>
+              <defs>
+                  {Object.values(defs)}
+              </defs>
               {
                 gradients
               }


### PR DESCRIPTION
Addresses https://github.com/mariusbrataas/flowpoints.js/issues/2

Added ability to display arrows controlled at Flowspace and/or individual Flowpoint level. Flowpoint when specified always overrides Flowspace arrow settings.

Arrows correctly take on the colour of the connection line for both forwards and backwards. For transition colours, colour displays as per colour for each each of line.

Arrows scale with stroke-width of connection line, Arrows auto-rotate according to input direction. Due to current path generation these are always perpendicular when meeting a flowpoint. Note that when flowpoints are very close then the flow line doesn't always appear centred within arrowhead.

Demo updated with settings to choose arrows displayed (none, start, end, both).

Example image:
![flowpoints-arrows-demo](https://user-images.githubusercontent.com/45517096/79761415-50b9db00-8319-11ea-92ae-ebdb6f47cc6f.PNG)
