### PR TITLE
Fix captured state in onClick closures

### DIFF
--- a/src/Flowpoint.js
+++ b/src/Flowpoint.js
@@ -82,6 +82,14 @@ export default class Flowpoint extends Component {
         }
       }
     })
+
+    // When a Flowpoint component is used inside a functional 
+    // component, the onClick handler that was passed in is
+    // likely to have captured state inside the resulting closure. 
+    // This becomes a problem when useState hook gets involved.
+    if ('onClick' in props && props.onClick !== this.onClick) {
+      this.onClick = props.onClick;
+    }
   }
 
 


### PR DESCRIPTION
When a Flowpoint component is used inside a functional component with useState hooks, the onClick handler that is passed in as a prop captures a snapshot of the state. Subsequent renders may update said state and pass in a new instance of an onClick handler, that has captured updated state. However, the onClick handler reference that is maintained inside the Flowpoint component does not get updated.